### PR TITLE
Turn off Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,7 +494,6 @@ function(WAVM_SET_TARGET_COMPILE_OPTIONS TARGET_NAME)
 		# Compile with all+extra warnings and fatal warnings
 		target_compile_options(${TARGET_NAME} PRIVATE "-Wall")
 		target_compile_options(${TARGET_NAME} PRIVATE "-Wextra")
-		target_compile_options(${TARGET_NAME} PRIVATE "-Werror")
 
 		# Disable RTTI to allow linking against a build of LLVM that was compiled without it.
 		target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)


### PR DESCRIPTION
Warnings are added by newer compilers and break using WAVM as a dependency